### PR TITLE
Update delete index for edge case in _create_imgs_matrix

### DIFF
--- a/difPy/dif.py
+++ b/difPy/dif.py
@@ -252,6 +252,8 @@ class dif:
                         if len(img.shape) == 2:
                             img = skimage.color.gray2rgb(img)
                         imgs_matrix.append(img)
+                    else:
+                        delete_index.append(count)
                 except:
                     delete_index.append(count)
             else:


### PR DESCRIPTION
The edge case shown here might cause Issue #25 

This fix might not be the appropriate behavior when `type(img) != np.ndarray` but I thought it might help!