### PR TITLE
added argument to disable recursive search for duplicate images

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,17 @@ difPy_stats_xxx.json
 DifPy has the following optional parameters:
 
 ```python
-dif(directory_A, directory_B, similarity="normal", px_size=50, 
+dif(directory_A, directory_B, recursive=True, similarity="normal", px_size=50, 
     show_progress=True, show_output=False, delete=False, silent_del=False)
 ```
+### recursive (bool)
+
+Per default, difPy will search for duplicate images also in subfolders. If set to ``False``, subfolders will not be scanned. 
+
+```True```= (default) use subfolders
+
+```False``` = don't use subfolders
+
 ### similarity (str, int)
 
 Depending on which use-case you want to apply difPy for, the granularity for the classification of the images can be adjusted. DifPy can f. e. search for exact matching duplicate images, or images that look similar, but are not necessarily duplicates.


### PR DESCRIPTION
Hi Elise,
I really appreciated your work on difPy. Thanks, it saved a lot of time while cleaning up my 2TB Nextcloud image-storage with many duplicates.

In my case, I had to disable the recursive search, since I sometimes store duplicates in subfolder, for example to share a collection with friends. I thought it might be cool to add this option upstream.