### PR TITLE
Use python 3.6 compatible directory nesting check

### DIFF
--- a/difPy/dif.py
+++ b/difPy/dif.py
@@ -142,8 +142,11 @@ class dif:
         if len(set(paths)) == 1:
             raise ValueError('An attempt to compare the directory with itself.')
         path1, path2 = paths
-        if path1.is_relative_to(path2) or path2.is_relative_to(path1):
-            raise ValueError('One directory belongs to another.')
+        common_path = os.path.commonpath(paths)
+        normalized_path1 = os.path.commonpath([path1])
+        normalized_path2 = os.path.commonpath([path2])
+        if common_path == normalized_path1 or common_path == normalized_path2:
+            raise ValueError('One directory belongs to another')
     
     # Function that creates a list of matrices for each image found in the folders
     def _create_imgs_matrix(directory, px_size, recursive, show_progress):


### PR DESCRIPTION
This PR is meant to fix #52 which seems to affect people running python versions smaller than 3.9, as described in https://github.com/elisemercury/Duplicate-Image-Finder/issues/52#issuecomment-1433278228

The contribution guide mentions openning the PR to the development branch, but I didn't find it.

I tested this in both macos and debian (via docker container). I don't have a windows machine available for testing, but it should work properly, the docs mention that `os.path.commonpath` is available for windows and unix ([source](https://docs.python.org/3/library/os.path.html#os.path.commonpath))

This should work for python versions as low as 3.6.

Thanks for the project!!

ps. I based my solution on this great so post https://stackoverflow.com/a/37095733