### PR TITLE
Fix bug in fast_search argument

### DIFF
--- a/difPy/dif.py
+++ b/difPy/dif.py
@@ -483,7 +483,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Find duplicate or similar images on your computer with difPy - https://github.com/elisemercury/Duplicate-Image-Finder')
     parser.add_argument('-D', '--directory', type=str, nargs='+', help='Directory to search for images.', required=True)
     parser.add_argument('-Z', '--output_directory', type=str, help='Output directory for the difPy result files. Default is working dir.', required=False, default=None)
-    parser.add_argument('-f', '--fast_search', type=str, help='Use difPys Fast Search Algorithm.', required=False, choices=[True, False], default=True)
+    parser.add_argument('-f', '--fast_search', type=bool, help='Use difPys Fast Search Algorithm.', required=False, choices=[True, False], default=True)
     parser.add_argument('-r', '--recursive', type=bool, help='Scan subfolders for duplicate images', required=False, choices=[True, False], default=True)
     parser.add_argument('-s', '--similarity', type=_help._type_str_int, help='Similarity grade.', required=False, default='duplicates')
     parser.add_argument('-px', '--px_size', type=int, help='Compression size of images in pixels.', required=False, default=50)


### PR DESCRIPTION
Fix for a type error in the `-f/--fast_search` argument definition, which was causing an error when the user attempted to define that parameter; specifically:  `error: argument -f/--fast_search: invalid choice: 'True' (choose from True, False)`