### PR TITLE
Search within files list option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ dif = difPy.build(["C:/Path/to/Folder_A/", "C:/Path/to/Folder_B/", "C:/Path/to/F
 search = difPy.search(dif)
 ``` 
 
+To search for duplicates **within files list**:
+
+```python
+import difPy
+dif = difPy.build(["C:/Path/to/Folder_A/image01.jpg", "C:/Path/to/Folder_B/image02.jpg", "C:/Path/to/Folder_C/image03.jpg", ... ])
+search = difPy.search(dif)
+``` 
+
 Folder paths can be specified as standalone Python strings, or within a list. With `difPy.build()`, difPy first scans the images in the provided folders and builds a collection of images by generating image tensors. `difPy.search()` then starts the search for duplicate images.
 
 :notebook: For a **detailed usage guide**, please view the official **[difPy Usage Documentation](https://difpy.readthedocs.io/)**.

--- a/difPy/dif.py
+++ b/difPy/dif.py
@@ -25,7 +25,7 @@ class build:
         Parameters
         ----------
         directory : str, list
-            Paths of the directories to be searched
+            Paths of the directories or the files to be searched
         recursive : bool (optional)
             Search recursively within the directories (default is True)
         in_folder : bool (optional)
@@ -108,11 +108,14 @@ class build:
         if self.__in_folder:
             # Search directories separately
             directories = []
+            files = []
             for dir in self.__directory:
-                directories += glob(str(dir) + '/**/', recursive=self.__recursive)
+                if os.path.isdir(dir):
+                    directories += glob(str(dir) + '/**/', recursive=self.__recursive)
+                elif os.path.isfile(dir):
+                    files.append(dir)
             for dir in directories:
-                files = glob(str(dir) + '/*', recursive=self.__recursive)
-                
+                files += glob(str(dir) + '/*', recursive=self.__recursive)
                 valid_files, skip_files = self._validate_files(files)
                 valid_files_all.append(valid_files)
                 if len(skip_files) > 0:
@@ -121,7 +124,10 @@ class build:
         else:
             # Search union of all directories
             for dir in self.__directory:
-                files = glob(str(dir) + '/**', recursive=self.__recursive)
+                if os.path.isdir(dir):
+                    files = glob(str(dir) + '/**', recursive=self.__recursive)
+                elif os.path.isfile(dir):
+                    files = (dir, )
                 valid_files, skip_files = self._validate_files(files)
                 valid_files_all = np.concatenate((valid_files_all, valid_files), axis=None)
                 if len(skip_files) > 0:
@@ -500,7 +506,7 @@ class _validate:
         # Check if the directory exists
         for dir in directory:
             dir = Path(dir)
-            if not os.path.isdir(dir):
+            if not (os.path.isdir(dir) or os.path.isfile(dir)):
                 raise FileNotFoundError(f'Directory "{str(dir)}" does not exist')
             
         # Check if the directories provided are unique


### PR DESCRIPTION
The ability to specify a list of files to work with instead of specifying folders. I needed this to embed the module in the telegram bot, which detects duplicates of the sent photos. To limit the list of files being checked and not to move the files themselves, I can simply transfer the list.