### PR TITLE
Bug fix in 'same_dim' param

### DIFF
--- a/difPy/dif.py
+++ b/difPy/dif.py
@@ -891,9 +891,6 @@ class _validate_param:
         # Function that validates the 'same_dim' input parameter
         if not isinstance(same_dim, bool):
             raise Exception('Invalid value for "same_dim" parameter: must be of type BOOL.')
-        if same_dim:
-            if similarity > 0:
-                same_dim = False
         return same_dim
 
     def _show_progress(show_progress):


### PR DESCRIPTION
Fixes issue #119 that would cause difPy to set same_dim to 'true' when searching for similar images